### PR TITLE
Switch CSS dark mode from media query to class-based .dark selector

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.css": "tailwindcss"
+    }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -12,11 +14,9 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated dark mode support to use a class-based `.dark` selector instead of a media query.
  - Introduced a custom Tailwind CSS variant for improved dark mode styling.
- **Chores**
  - Added VS Code workspace settings to enhance Tailwind CSS support for CSS files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->